### PR TITLE
ADR14: Metadata changes

### DIFF
--- a/0014-runtime-signing-tx-with-hardware-wallet.md
+++ b/0014-runtime-signing-tx-with-hardware-wallet.md
@@ -6,6 +6,8 @@ Oasis SDK
 
 ## Changelog
 
+- 2023-01-27:
+  - Fix [Metadata](#metadata-parameter) `chain_context` encoding.
 - 2023-01-23:
   - Fix Deoxys-II field description in [Signing encrypted runtime
     transactions](#signing-encrypted-runtime-transactions) section.
@@ -325,7 +327,7 @@ Data is defined as:
 `Meta` contains the following fields:
 
 - `runtime_id`: 32-byte [runtime ID][runtime id]
-- `chain_context`: 32-byte [chain ID][chain context]
+- `chain_context`: 64-byte [chain ID][chain context]
 - `orig_to` (optional): 20-byte ethereum destination address
 
 ### Changes to Allowance transaction


### PR DESCRIPTION
Changes to ADR 14:
- Combine Metadata and Message fields into a single CBOR-encoded object with `metadata` and `tx` fields respectively.
- Fix [`metadata.chain_context`](#data-field-format) encoding.

Rationale:
1. You need to prase CBOR message in order to determine its size.
2. CBOR wrapped inside another CBOR is CBOR. This means you don't need any additional memory (as is the case, for example, in Base64) in order to parse the CBOR-encoded object (e.g. transaction) wrapped inside CBOR.

As a consequence, there is no added value, if we pass two separate Meta+Message CBOR-encoded messages to the hardware wallet, so we combine them inside a single Data CBOR-encoded map with `metadata` and `tx` fields.