### PR TITLE
ADR 15: Fix obsolete broken link

### DIFF
--- a/0015-vrf-per-block-entropy.md
+++ b/0015-vrf-per-block-entropy.md
@@ -106,4 +106,4 @@ be part of 0.37.x, so it is unknown when this will be possible to implement.
 ## References
 
 [1]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-vrf/
-[2]: https://github.com/tendermint/tendermint/blob/main/docs/rfc/rfc-013-abci%2B%2B.md
+[2]: https://github.com/cometbft/cometbft/blob/main/docs/rfc/tendermint-core/rfc-013-abci%2B%2B.md


### PR DESCRIPTION
The Tendermint (now ComentBFT) team reorganized their RFCs slightly.