### PR TITLE
ADR 8: Fix docs.oasis.io FAQ link

### DIFF
--- a/0008-standard-account-key-generation.md
+++ b/0008-standard-account-key-generation.md
@@ -584,7 +584,7 @@ the [Ledger] and [Trezor] hardware wallets.
 [tor-hd]:
   https://gitweb.torproject.org/torspec.git/tree/proposals/224-rend-spec-ng.txt#n2135
 [oasis-ledger-app]: https://github.com/LedgerHQ/app-oasis
-[bitpie]: https://github.com/oasisprotocol/docs/blob/main/docs/general/manage-tokens/faq.md
+[bitpie]: https://github.com/oasisprotocol/docs/blob/main/docs/general/manage-tokens/faq.mdx
 [Andrew Kozlik (SatoshiLabs)]: https://github.com/andrewkozlik
 [kozlik-comments]:
   https://github.com/satoshilabs/slips/issues/703#issuecomment-515213584


### PR DESCRIPTION
Merge after https://github.com/oasisprotocol/docs/pull/651 is merged.