### PR TITLE
ADR 10: Replace <= with ≤ to avoid linting errors

### DIFF
--- a/0010-vrf-elections.md
+++ b/0010-vrf-elections.md
@@ -36,7 +36,7 @@ following additions and extra clarifications:
   enforcing this when decoding.
 
 - When decoding s in the ECVRF_verify routine, the s scalar MUST fall
-  within the range 0 <= i < L.  This change will make proofs
+  within the range 0 &le; i < L.  This change will make proofs
   non-malleable.  Note that this check is unneeded for the c scalar
   as it is 128-bits, and thus will always lie within the valid range.
   This check was not present in the IETF draft prior to version 10.

--- a/0014-runtime-signing-tx-with-hardware-wallet.md
+++ b/0014-runtime-signing-tx-with-hardware-wallet.md
@@ -142,7 +142,7 @@ The first three items in the derivation path are hardened.
 
 #### GET_ADDR_SR25519
 
-<!-- markdownlint-disable-next-line no-duplicate-header -->
+<!-- markdownlint-disable-next-line no-duplicate-heading -->
 ##### Command
 
 | Field      | Type           | Content                | Expected       |
@@ -160,7 +160,7 @@ The first three items in the derivation path are hardened.
 
 The first three items in the derivation path are hardened.
 
-<!-- markdownlint-disable-next-line no-duplicate-header -->
+<!-- markdownlint-disable-next-line no-duplicate-heading -->
 ##### Response
 
 | Field   | Type      | Content               | Note                     |
@@ -171,7 +171,7 @@ The first three items in the derivation path are hardened.
 
 #### SIGN_RT_ED25519
 
-<!-- markdownlint-disable-next-line no-duplicate-header -->
+<!-- markdownlint-disable-next-line no-duplicate-heading -->
 ##### Command
 
 | Field | Type     | Content                | Expected  |
@@ -188,7 +188,7 @@ The first packet/chunk includes only the derivation path.
 
 All other packets/chunks should contain message to sign.
 
-<!-- markdownlint-disable-next-line no-emphasis-as-header -->
+<!-- markdownlint-disable-next-line no-emphasis-as-heading -->
 *First Packet*
 
 | Field      | Type     | Content                | Expected  |
@@ -199,7 +199,7 @@ All other packets/chunks should contain message to sign.
 | Path[3]    | byte (4) | Derivation Path Data   | ?         |
 | Path[4]    | byte (4) | Derivation Path Data   | ?         |
 
-<!-- markdownlint-disable-next-line no-emphasis-as-header -->
+<!-- markdownlint-disable-next-line no-emphasis-as-heading -->
 *Other Chunks/Packets*
 
 | Field   | Type     | Content              | Expected |
@@ -213,7 +213,7 @@ Data is defined as:
 | Meta    | bytes..  | CBOR metadata     |              |
 | Message | bytes..  | CBOR data to sign |              |
 
-<!-- markdownlint-disable-next-line no-duplicate-header -->
+<!-- markdownlint-disable-next-line no-duplicate-heading -->
 ##### Response
 
 | Field   | Type      | Content     | Note                     |
@@ -223,7 +223,7 @@ Data is defined as:
 
 #### SIGN_RT_SECP256K1
 
-<!-- markdownlint-disable-next-line no-duplicate-header -->
+<!-- markdownlint-disable-next-line no-duplicate-heading -->
 ##### Command
 
 | Field | Type     | Content                | Expected  |
@@ -240,7 +240,7 @@ The first packet/chunk includes only the derivation path.
 
 All other packets/chunks should contain message to sign.
 
-<!-- markdownlint-disable-next-line no-emphasis-as-header -->
+<!-- markdownlint-disable-next-line no-emphasis-as-heading -->
 *First Packet*
 
 | Field      | Type     | Content                | Expected  |
@@ -251,7 +251,7 @@ All other packets/chunks should contain message to sign.
 | Path[3]    | byte (4) | Derivation Path Data   | ?         |
 | Path[4]    | byte (4) | Derivation Path Data   | ?         |
 
-<!-- markdownlint-disable-next-line no-emphasis-as-header -->
+<!-- markdownlint-disable-next-line no-emphasis-as-heading -->
 *Other Chunks/Packets*
 
 | Field   | Type     | Content              | Expected |
@@ -265,7 +265,7 @@ Data is defined as:
 | Meta    | bytes..  | CBOR metadata     |              |
 | Message | bytes..  | CBOR data to sign |              |
 
-<!-- markdownlint-disable-next-line no-duplicate-header -->
+<!-- markdownlint-disable-next-line no-duplicate-heading -->
 ##### Response
 
 | Field   | Type      | Content     | Note                     |
@@ -275,7 +275,7 @@ Data is defined as:
 
 #### SIGN_RT_SR25519
 
-<!-- markdownlint-disable-next-line no-duplicate-header -->
+<!-- markdownlint-disable-next-line no-duplicate-heading -->
 ##### Command
 
 | Field | Type     | Content                | Expected  |
@@ -292,7 +292,7 @@ The first packet/chunk includes only the derivation path.
 
 All other packets/chunks should contain message to sign.
 
-<!-- markdownlint-disable-next-line no-emphasis-as-header -->
+<!-- markdownlint-disable-next-line no-emphasis-as-heading -->
 *First Packet*
 
 | Field      | Type     | Content                | Expected  |
@@ -303,7 +303,7 @@ All other packets/chunks should contain message to sign.
 | Path[3]    | byte (4) | Derivation Path Data   | ?         |
 | Path[4]    | byte (4) | Derivation Path Data   | ?         |
 
-<!-- markdownlint-disable-next-line no-emphasis-as-header -->
+<!-- markdownlint-disable-next-line no-emphasis-as-heading -->
 *Other Chunks/Packets*
 
 | Field   | Type     | Content              | Expected |
@@ -317,7 +317,7 @@ Data is defined as:
 | Meta    | bytes..  | CBOR metadata     |              |
 | Message | bytes..  | CBOR data to sign |              |
 
-<!-- markdownlint-disable-next-line no-duplicate-header -->
+<!-- markdownlint-disable-next-line no-duplicate-heading -->
 ##### Response
 
 | Field   | Type      | Content     | Note                     |
@@ -639,7 +639,7 @@ We propose the following UI for the [`contracts.Upgrade`] method:
 The Data screen behavior is the same as for the
 [contract instantiate](#instantiating-smart-contract) transaction.
 
-<!-- markdownlint-disable-next-line no-duplicate-header -->
+<!-- markdownlint-disable-next-line no-duplicate-heading -->
 #### Example
 
 To upload, instantiate and call the [hello world example] running on Testnet
@@ -723,7 +723,7 @@ In this case the hardware wallet renders the following UI.
 [`evm.Create`] method will not be managed by the hardware wallet because the
 size of the EVM byte code may easily exceed the wallet's encrypted memory size.
 
-<!-- markdownlint-disable-next-line no-duplicate-header -->
+<!-- markdownlint-disable-next-line no-duplicate-heading -->
 #### Calling smart contract
 
 In contrast to `contracts.Call`, [`evm.Call`] method requires contract ABI and


### PR DESCRIPTION
Docusaurus 3.0.1 MDX linter complains:

```
Error: MDX compilation failed for file "/home/oa/docs/docs/adrs/0010-vrf-elections.md"
Cause: Unexpected character `=` (U+003D) before name, expected a character that can start a name, such as a letter, `$`, or `_`
Details:
{
  "column": 23,
  "message": "Unexpected character `=` (U+003D) before name, expected a character that can start a name, such as a letter, `$`, or `_`",
  "line": 39,
  "name": "39:23",
  "place": {
    "line": 39,
    "column": 23,
    "offset": 1093,
    "_index": 2,
    "_bufferIndex": 20
  },
  "reason": "Unexpected character `=` (U+003D) before name, expected a character that can start a name, such as a letter, `$`, or `_`",
  "ruleId": "unexpected-character",
  "source": "micromark-extension-mdx-jsx",
  "url": "https://github.com/micromark/micromark-extension-mdx-jsx#unexpected-character-at-expected-expect"
}
error Command failed with exit code 1.
```

Replacing `<=` with `≤` or `&le;` seems to fix it.